### PR TITLE
Play indicator tone with voip calls as well.

### DIFF
--- a/basic/policy/audio_volume_rules.pl
+++ b/basic/policy/audio_volume_rules.pl
@@ -385,7 +385,8 @@ ringtone_limit(Value) :-
 cstone_limit(Value) :-
     % cstone volume is 0 if feedback tones are disabled and call is not active
     (is_silent_feedback,
-     not(context:call_state(active))) *-> Value=0;
+     not(context:call_state(active)),
+     not(context:call_state(voip))) *-> Value=0;
     % Default volume
     Value=100.
 


### PR DESCRIPTION
If voip call is active we should play indicator tone regardless of the
silent mode state.
